### PR TITLE
earning_date_update service

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"fmt"
+	"encoding/csv"
 	"io/ioutil"
 	"net/http"
 )
 
-func FetchAPIData(functionName, symbol, apiKey string) ([]byte, error) {
+func FetchAPIData(functionName string, symbol string, apiKey string) ([]byte, error) {
 	url := fmt.Sprintf("https://www.alphavantage.co/query?function=%s&symbol=%s&apikey=%s", functionName, symbol, apiKey)
 	resp, err := http.Get(url)
 	
@@ -27,4 +28,21 @@ func FetchAPIData(functionName, symbol, apiKey string) ([]byte, error) {
 	// fmt.Println("Raw JSON response:")
 	// fmt.Println(string(body))
 	return ioutil.ReadAll(resp.Body)
+}
+
+func FetchCSVReader(functionName string, horizon string, apiKey string) (*csv.Reader, func(), error) {
+	url := fmt.Sprintf("https://www.alphavantage.co/query?function=%s&horizon=%s&apikey=%s", functionName, horizon, apiKey)
+	// Make an HTTP GET request
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error making GET request: %v", err)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("received non-200 status code: %d", resp.StatusCode)
+	}
+
+	// Return the csv.Reader object
+	return csv.NewReader(resp.Body), func() { resp.Body.Close() }, nil
 }

--- a/cmd/earning_date_update/earning_date_update.go
+++ b/cmd/earning_date_update/earning_date_update.go
@@ -1,0 +1,43 @@
+package main
+import (
+	"os"
+	"financial_project/api"
+	"financial_project/config"
+	"financial_project/db"
+	"financial_project/services"
+	"financial_project/logmanager"
+)
+
+func main() {
+	// Call the main application logic
+	code := run()
+	
+	// Exit with the appropriate code
+	os.Exit(code)
+}
+
+func run() int {
+	cfg := config.LoadConfig()
+	dbManager, err := db.NewDBManager(cfg.DBDSN)
+	if err != nil {
+		logmanager.Errorf("Error initializing database: %v", err)
+		return 1
+	}
+	defer dbManager.Close()
+	function := "EARNINGS_CALENDAR"
+	horizon := "2month"
+	reader, cleanup, err := api.FetchCSVReader(function,horizon,cfg.APIKey)
+	if err != nil {
+		logmanager.Errorf("Error fetching CSV: %v\n", err)
+		return 1
+	}
+	defer cleanup()
+
+	// Read and process the CSV file
+	if err := services.EarningCalendarProcessor(reader, dbManager); err != nil {
+		logmanager.Errorf("Error processing earning calendar: %v", err)
+		return 1
+	}
+	
+	return 0
+}

--- a/db/queries.go
+++ b/db/queries.go
@@ -287,7 +287,7 @@ func (m *DBManager) InsertCompany(report models.Company) error {
 }
 
 func (m *DBManager) DeleteCompany(symbol string) error {
-	query := "DELETE FROM company WHERE symbol = ?"
+	query := fmt.Sprintf(`DELETE FROM company WHERE symbol = ?`)
     result, err := m.DB.Exec(query, symbol)
     if err != nil {
         return fmt.Errorf("failed to delete record: %v", err)
@@ -299,6 +299,15 @@ func (m *DBManager) DeleteCompany(symbol string) error {
     }
 
     fmt.Printf("Deleted %d record(s)\n", rowsAffected)
+    return nil
+}
+
+func (m *DBManager) UpdateCompanyEarningDate(symbol string, earning_date string) error {
+	query := "UPDATE company SET next_earning_report = ? WHERE symbol = ?"
+    _, err := m.DB.Exec(query, earning_date,symbol)
+	if err != nil {
+		logmanager.Errorf("Failed to retrieve affected rows: %v", err)
+	}
     return nil
 }
 

--- a/services/earning_calendar_processor.go
+++ b/services/earning_calendar_processor.go
@@ -1,0 +1,37 @@
+package services
+
+import (
+	"encoding/csv"
+	// "financial_project/models"
+	"financial_project/db"
+	"financial_project/logmanager"
+)
+
+func EarningCalendarProcessor(reader *csv.Reader, dbManager *db.DBManager) error {
+	// Read and process the CSV file
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			logmanager.Errorf("Error reading CSV: %v\n", err)
+			return err
+		}
+		// Extract and print Symbol and ReportDate
+		// logmanager.Infof("Symbol: %s, ReportDate: %s\n", record[0], record[2])
+		exists, err := dbManager.CompanyExists(record[0])
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			if err := dbManager.UpdateCompanyEarningDate(record[0], record[2]); err != nil {
+				return err
+			}
+			logmanager.Infof("Updated %s with new earning date %s\n", record[0], record[2])
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This feature pulls the list of companies which have earning report in next 2 months and update the next_earning_report column in company table. The reason for this intention is that I want to limit the number of call per day. After having the next_earning_report, the service can make the call at the end of the day.